### PR TITLE
Zero-ing out tokens from memory

### DIFF
--- a/templates/server-solution/src/MyAppWithMud.ServiceDefaults/Extensions.cs
+++ b/templates/server-solution/src/MyAppWithMud.ServiceDefaults/Extensions.cs
@@ -3,12 +3,14 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
-namespace Microsoft.Extensions.Hosting;
+namespace MyAppWithMud.ServiceDefaults;
 
 // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.

--- a/templates/server-solution/src/MyAppWithMud.Web/Program.cs
+++ b/templates/server-solution/src/MyAppWithMud.Web/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+﻿using MyAppWithMud.ServiceDefaults;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.Options;
 using MyAppWithMud.Components;

--- a/templates/server-solution/src/MyAppWithMud.Web/SessionManagement/OidcEvents.cs
+++ b/templates/server-solution/src/MyAppWithMud.Web/SessionManagement/OidcEvents.cs
@@ -11,6 +11,13 @@ public class OidcEvents : OpenIdConnectEvents
     private readonly IUserTokenManagementService _service;
     private readonly ILogger _logger;
 
+    // Constants for claim types and event URIs
+    private const string LogoutTokenParameter = "logout_token";
+    private const string EventsClaim = "events";
+    private const string SubClaim = "sub";
+    private const string SidClaim = "sid";
+    private const string BackchannelLogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
     public OidcEvents(IUserTokenStore store, IUserAccessor userAccessor, IUserTokenManagementService service, ILogger<OidcEvents> logger)
     {
         _store = store;
@@ -27,30 +34,38 @@ public class OidcEvents : OpenIdConnectEvents
 
     public override async Task RemoteSignOut(RemoteSignOutContext context)
     {
-        if (!TryGetLogoutToken(context, out var token) || token == null)
+        try
         {
-            return;
-        }
+            if (!TryGetLogoutToken(context, out var token) || token == null)
+            {
+                return;
+            }
 
-        var principal = await ValidateLogoutTokenAsync(context, token);
-        if (principal == null)
+            var principal = await ValidateLogoutTokenAsync(context, token);
+            if (principal == null)
+            {
+                return;
+            }
+
+            if (!HasValidLogoutEvent(principal, context))
+            {
+                return;
+            }
+
+            if (!HasSubOrSid(principal, context))
+            {
+                return;
+            }
+
+            await _service.RevokeRefreshTokenAsync(principal);
+            context.Principal = principal;
+            context.Success();
+        }
+        catch (Exception ex)
         {
-            return;
+            _logger.LogError(ex, "Exception during RemoteSignOut");
+            HandleBadRequest(context);
         }
-
-        if (!HasValidLogoutEvent(principal, context))
-        {
-            return;
-        }
-
-        if (!HasSubOrSid(principal, context))
-        {
-            return;
-        }
-
-        await _service.RevokeRefreshTokenAsync(principal);
-        context.Principal = principal;
-        context.Success();
     }
 
     private bool TryGetLogoutToken(RemoteSignOutContext context, out string? token)
@@ -62,9 +77,9 @@ public class OidcEvents : OpenIdConnectEvents
             HandleBadRequest(context);
             return false;
         }
-        if (!context.ProtocolMessage.Parameters.TryGetValue("logout_token", out token))
+        if (!context.ProtocolMessage.Parameters.TryGetValue(LogoutTokenParameter, out token))
         {
-            _logger.LogError("logout_token must not be null");
+            _logger.LogError("{LogoutTokenParameter} must not be null", LogoutTokenParameter);
             HandleBadRequest(context);
             return false;
         }
@@ -73,34 +88,43 @@ public class OidcEvents : OpenIdConnectEvents
 
     private async Task<ClaimsPrincipal?> ValidateLogoutTokenAsync(RemoteSignOutContext context, string token)
     {
-        var validationParameters = context.Options.TokenValidationParameters.Clone();
-        var configuration = await context.Options.ConfigurationManager!.GetConfigurationAsync(context.HttpContext.RequestAborted);
-        var issuer = new[] { configuration.Issuer };
-        validationParameters.ValidIssuers = validationParameters.ValidIssuers?.Concat(issuer) ?? issuer;
-        validationParameters.IssuerSigningKeys = validationParameters.IssuerSigningKeys?.Concat(configuration.SigningKeys)
-            ?? configuration.SigningKeys;
-        var tokenValidationResult = await context.Options.TokenHandler.ValidateTokenAsync(token, validationParameters);
-        if (!tokenValidationResult.IsValid)
+        try
         {
-            _logger.LogError(tokenValidationResult.Exception, "erro on validating token");
+            var validationParameters = context.Options.TokenValidationParameters.Clone();
+            var configuration = await context.Options.ConfigurationManager!.GetConfigurationAsync(context.HttpContext.RequestAborted);
+            var issuer = new[] { configuration.Issuer };
+            validationParameters.ValidIssuers = validationParameters.ValidIssuers?.Concat(issuer) ?? issuer;
+            validationParameters.IssuerSigningKeys = validationParameters.IssuerSigningKeys?.Concat(configuration.SigningKeys)
+                ?? configuration.SigningKeys;
+            var tokenValidationResult = await context.Options.TokenHandler.ValidateTokenAsync(token, validationParameters);
+            if (!tokenValidationResult.IsValid)
+            {
+                _logger.LogError(tokenValidationResult.Exception, "Error validating logout token");
+                HandleBadRequest(context);
+                return null;
+            }
+            return new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception during ValidateLogoutTokenAsync");
             HandleBadRequest(context);
             return null;
         }
-        return new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
     }
 
     private bool HasValidLogoutEvent(ClaimsPrincipal principal, RemoteSignOutContext context)
     {
-        var events = principal.FindFirst("events")?.Value;
+        var events = principal.FindFirst(EventsClaim)?.Value;
         if (string.IsNullOrWhiteSpace(events))
         {
-            _logger.LogError("events claim is required");
+            _logger.LogError("{EventsClaim} claim is required", EventsClaim);
             HandleBadRequest(context);
             return false;
         }
-        if (!events.Contains("http://schemas.openid.net/event/backchannel-logout"))
+        if (!events.Contains(BackchannelLogoutEvent))
         {
-            _logger.LogError("events must be 'http://schemas.openid.net/event/backchannel-logout'");
+            _logger.LogError("{EventsClaim} must contain '{BackchannelLogoutEvent}'", EventsClaim, BackchannelLogoutEvent);
             HandleBadRequest(context);
             return false;
         }
@@ -109,11 +133,11 @@ public class OidcEvents : OpenIdConnectEvents
 
     private bool HasSubOrSid(ClaimsPrincipal principal, RemoteSignOutContext context)
     {
-        var sub = principal.FindFirst("sub")?.Value;
-        var sid = principal.FindFirst("sid")?.Value;
+        var sub = principal.FindFirst(SubClaim)?.Value;
+        var sid = principal.FindFirst(SidClaim)?.Value;
         if (string.IsNullOrEmpty(sub) && string.IsNullOrEmpty(sid))
         {
-            _logger.LogError("Token must contain 'sub' or 'sid'");
+            _logger.LogError("Token must contain '{SubClaim}' or '{SidClaim}'", SubClaim, SidClaim);
             HandleBadRequest(context);
             return false;
         }
@@ -130,16 +154,35 @@ public class OidcEvents : OpenIdConnectEvents
 
     public override async Task TokenValidated(TokenValidatedContext context)
     {
-        var exp = DateTimeOffset.UtcNow.AddSeconds(double.Parse(context.TokenEndpointResponse!.ExpiresIn));
-
-        await _store.StoreTokenAsync(context.Principal!, new UserToken
+        if (context.TokenEndpointResponse == null)
         {
-            AccessToken = context.TokenEndpointResponse.AccessToken,
-            AccessTokenType = context.TokenEndpointResponse.TokenType,
-            Expiration = exp,
-            RefreshToken = context.TokenEndpointResponse.RefreshToken,
-            Scope = context.TokenEndpointResponse.Scope
-        });
+            _logger.LogError("TokenEndpointResponse is null in TokenValidated");
+            return;
+        }
+
+        if (!double.TryParse(context.TokenEndpointResponse.ExpiresIn, out var expiresInSeconds))
+        {
+            _logger.LogError("ExpiresIn is not a valid number: {ExpiresIn}", context.TokenEndpointResponse.ExpiresIn);
+            return;
+        }
+
+        var exp = DateTimeOffset.UtcNow.AddSeconds(expiresInSeconds);
+
+        try
+        {
+            await _store.StoreTokenAsync(context.Principal!, new UserToken
+            {
+                AccessToken = context.TokenEndpointResponse.AccessToken,
+                AccessTokenType = context.TokenEndpointResponse.TokenType,
+                Expiration = exp,
+                RefreshToken = context.TokenEndpointResponse.RefreshToken,
+                Scope = context.TokenEndpointResponse.Scope
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception storing token in TokenValidated");
+        }
 
         await base.TokenValidated(context);
     }


### PR DESCRIPTION
• Improved memory security in ServerSideTokenStore by zeroing out sensitive fields (AccessToken, RefreshToken, IdToken) before removing tokens from memory.